### PR TITLE
Leads endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### head
 
+* Support for Leads endpoint
+
 ### 2.5.0
 
 * Support for Careers endpoint

--- a/src/Flippa.js
+++ b/src/Flippa.js
@@ -2,6 +2,7 @@ import Client from "./Client";
 
 import Career from "./resources/Career";
 import Careers from "./resources/Careers";
+import Lead from "./resources/Lead";
 import Listing from "./resources/Listing";
 import Listings from "./resources/Listings";
 import Metrics from "./resources/Metrics";
@@ -86,4 +87,7 @@ export default class Flippa {
     return new Careers(this.client);
   }
 
+  get lead() {
+    return new Lead(this.client);
+  }
 };

--- a/src/resources/Lead.js
+++ b/src/resources/Lead.js
@@ -1,0 +1,7 @@
+import Resource from '../Resource'
+
+export default class Lead extends Resource {
+  create(params={}) {
+    return this.client.post("/lead", params);
+  }
+}

--- a/test/unit/Flippa_test.js
+++ b/test/unit/Flippa_test.js
@@ -4,6 +4,7 @@ import Flippa from "../../src/Flippa";
 
 import Career from "../../src/resources/Career";
 import Careers from "../../src/resources/Careers";
+import Lead from "../../src/resources/Lead";
 import Listing from "../../src/resources/Listing";
 import Listings from "../../src/resources/Listings";
 import Metrics from "../../src/resources/Metrics";
@@ -121,6 +122,14 @@ describe("Flippa", () => {
       const flippa = new Flippa();
 
       expect(flippa.supportEnquiries).to.be.an.instanceOf(SupportEnquiries);
+    });
+  });
+
+  describe("Lead", () => {
+    it("returns a new Lead", () => {
+      const flippa = new Flippa();
+
+      expect(flippa.lead).to.be.an.instanceOf(Lead);
     });
   });
 });

--- a/test/unit/resources/Lead_test.js
+++ b/test/unit/resources/Lead_test.js
@@ -1,0 +1,25 @@
+import chai from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+import Lead from "../../../src/resources/Lead";
+
+describe("Lead", () => {
+  describe("create", () => {
+    it("calls POST /lead with the given parameters", () => {
+      const post = sinon.spy();
+      const client = { post };
+      const lead = new Lead(client);
+      const params = {
+        message: "Hello? Yes this is dog."
+      };
+
+      lead.create(params);
+
+      expect(post).to.have.been.calledWith("/lead", params);
+    });
+  });
+});


### PR DESCRIPTION
### Overview

Adds support for lead submissions via the ```/leads``` endpoint
