### PR TITLE
Fix lead posting to incorrect endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### head
 
+* Fix Leads not posting to correct endpoint
+
 ### 2.6.0
 
 * Support for Leads endpoint

--- a/src/resources/Lead.js
+++ b/src/resources/Lead.js
@@ -2,6 +2,6 @@ import Resource from '../Resource'
 
 export default class Lead extends Resource {
   create(params={}) {
-    return this.client.post("/lead", params);
+    return this.client.post("/leads", params);
   }
 }

--- a/test/unit/resources/Lead_test.js
+++ b/test/unit/resources/Lead_test.js
@@ -19,7 +19,7 @@ describe("Lead", () => {
 
       lead.create(params);
 
-      expect(post).to.have.been.calledWith("/lead", params);
+      expect(post).to.have.been.calledWith("/leads", params);
     });
   });
 });


### PR DESCRIPTION
### Overview

Lead was posting to ```/lead```. The endpoint is ```/leads```