### PR TITLE
Add timeout to requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### head
 
+### 2.7.0
+
+* Add timeout to all requests
+
 ### 2.6.1
 
 * Fix Leads not posting to correct endpoint

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ flippa
 
 For more usage examples, see [the documentation](http://developers.flippa.com).
 
+# Timeout
+
+All requests timeout after 15s by default. This is configurable via the
+`timeout` option (in ms).
+
+Example:
+
+```js
+// set default timeout to 10s
+var flippa = new Flippa({timeout: 10000});
+```
+
 # Development
 
 Running tests:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flippa",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "API client for Flippa.com.",
   "readme": "README.md",
   "main": "dist/Flippa.js",

--- a/src/Client.js
+++ b/src/Client.js
@@ -5,6 +5,7 @@ export default class Client {
   constructor(opts={}) {
     this.baseEndpointURL = opts.baseEndpointURL || "https://api.flippa.com/v3";
     this.accessToken = opts.accessToken || null;
+    this.timeout = opts.timeout || 15000;
   }
 
   get(endpoint, params={}) {
@@ -12,6 +13,7 @@ export default class Client {
       .get(this.baseEndpointURL + endpoint)
       .query(qs.stringify(params))
       .set("Accept", "application/json")
+      .timeout(this.timeout);
 
     this._setAuthorizationHeader(request);
 
@@ -23,6 +25,7 @@ export default class Client {
       .post(this.baseEndpointURL + endpoint)
       .set("Accept", "application/json")
       .send(params)
+      .timeout(this.timeout);
 
     this._setCookieHeader(request, cookies)
 
@@ -35,7 +38,8 @@ export default class Client {
     var request = Request
       .del(this.baseEndpointURL + endpoint)
       .set("Accept", "application/json")
-      .send(params);
+      .send(params)
+      .timeout(this.timeout);
 
     this._setAuthorizationHeader(request);
 


### PR DESCRIPTION
### Overview

Adds a configurable timeout to get, put and delete requests which defaults to 15 seconds