### PR TITLE
Allow retrieval of partner details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### head
 
+* Add the ability to retrieve partner page details
+
 ### 2.7.0
 
 * Add timeout to all requests
@@ -40,7 +42,7 @@
 
 * Support for watched item creation, watched item destruction, user creation,
   and user alert listing endpoints.
-* Breaking: Re-arangement of resource API methods.
+* Breaking: Re-arrangement of resource API methods.
 
 ### 1.0.0
 

--- a/src/Flippa.js
+++ b/src/Flippa.js
@@ -12,6 +12,7 @@ import Sessions from "./resources/Sessions";
 import SupportEnquiries from "./resources/SupportEnquiries";
 import User from "./resources/User";
 import Users from "./resources/Users";
+import PartnerPage from "./resources/PartnerPage";
 
 import Promise from "bluebird";
 
@@ -89,5 +90,9 @@ export default class Flippa {
 
   get lead() {
     return new Lead(this.client);
+  }
+
+  partnerPage(pageName) {
+    return new PartnerPage(this.client, pageName);
   }
 };

--- a/src/resources/PartnerPage.js
+++ b/src/resources/PartnerPage.js
@@ -1,0 +1,13 @@
+import Resource from '../Resource'
+
+export default class PartnerPage extends Resource {
+  constructor(client, pageName) {
+    super(client);
+    this.pageName = pageName;
+  }
+
+  retrieve() {
+    return this.client.get(`/partner-pages/${this.pageName}`);
+  }
+
+}

--- a/test/unit/Flippa_test.js
+++ b/test/unit/Flippa_test.js
@@ -14,6 +14,7 @@ import Sessions from "../../src/resources/Sessions";
 import SupportEnquiries from "../../src/resources/SupportEnquiries";
 import User from "../../src/resources/User";
 import Users from "../../src/resources/Users";
+import PartnerPage from "../../src/resources/PartnerPage";
 
 const expect = chai.expect;
 
@@ -130,6 +131,15 @@ describe("Flippa", () => {
       const flippa = new Flippa();
 
       expect(flippa.lead).to.be.an.instanceOf(Lead);
+    });
+  });
+
+  describe("PartnerPage", () => {
+    it("returns a new PartnerPage", () => {
+      const flippa = new Flippa();
+
+      expect(flippa.partnerPage("domainHoldings")).to.be.an.instanceOf(PartnerPage);
+      expect(flippa.partnerPage("domainHoldings").pageName).to.eq("domainHoldings");
     });
   });
 });

--- a/test/unit/resources/PartnerPage_test.js
+++ b/test/unit/resources/PartnerPage_test.js
@@ -1,0 +1,22 @@
+import chai from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+import PartnerPage from "../../../src/resources/PartnerPage";
+
+describe("PartnerPage", () => {
+  describe("retrieve", () => {
+    it("calls GET /partner-pages/:partnerName", () => {
+      const get = sinon.spy();
+      const client = { get };
+      const partnerPage = new PartnerPage(client, 'domainHoldings');
+
+      partnerPage.retrieve();
+
+      expect(get).to.have.been.calledWith("/partner-pages/domainHoldings");
+    });
+  });
+});


### PR DESCRIPTION
### Background Context

We want to be able to retrieve partner details page and serve it to the MFE.
https://github.com/flippa/marketplace-frontend/pull/670

This will allow MFE to hit the resource partner page implemented in https://github.com/flippa/flippa-rails/pull/3932

### What’s this do?

- Allows partner page details to be retrieved using 
`this.client.partnerPage('pageName').retrieve()` which returns a promise once the query is rejected or resolved.

