### PR TITLE
Add functionality to retrieve intercom detail.

### DIFF
--- a/src/Flippa.js
+++ b/src/Flippa.js
@@ -13,6 +13,7 @@ import SupportEnquiries from "./resources/SupportEnquiries";
 import User from "./resources/User";
 import Users from "./resources/Users";
 import PartnerPage from "./resources/PartnerPage";
+import Intercom from "./resources/Intercom";
 
 import Promise from "bluebird";
 
@@ -94,5 +95,9 @@ export default class Flippa {
 
   partnerPage(pageName) {
     return new PartnerPage(this.client, pageName);
+  }
+
+  get intercom() {
+    return new Intercom(this.client);
   }
 };

--- a/src/resources/Intercom.js
+++ b/src/resources/Intercom.js
@@ -1,0 +1,7 @@
+import Resource from '../Resource'
+
+export default class Intercom extends Resource {
+  retrieve() {
+    return this.client.get('/intercom');
+  }
+}

--- a/test/unit/Flippa_test.js
+++ b/test/unit/Flippa_test.js
@@ -15,6 +15,7 @@ import SupportEnquiries from "../../src/resources/SupportEnquiries";
 import User from "../../src/resources/User";
 import Users from "../../src/resources/Users";
 import PartnerPage from "../../src/resources/PartnerPage";
+import Intercom from "../../src/resources/Intercom";
 
 const expect = chai.expect;
 
@@ -142,4 +143,12 @@ describe("Flippa", () => {
       expect(flippa.partnerPage("domainHoldings").pageName).to.eq("domainHoldings");
     });
   });
+
+  describe("intercom", () => {
+    it("returns a new Intercom", () => {
+      const flippa = new Flippa();
+
+      expect(flippa.intercom).to.be.an.instanceOf(Intercom);
+    });
+  })
 });

--- a/test/unit/resources/Intercom_test.js
+++ b/test/unit/resources/Intercom_test.js
@@ -1,0 +1,21 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import Intercom from '../../../src/resources/Intercom';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe('Intercom', () => {
+  describe('retrieve', () => {
+    it('calls GET /intercom', () => {
+      const get = sinon.spy();
+      const client = { get };
+      const intercom = new Intercom(client);
+
+      intercom.retrieve();
+
+      expect(get).to.have.been.calledWith('/intercom');
+    });
+  });
+});


### PR DESCRIPTION
### Background Context
We want to be able to retrieve intercom details from the `/intercom` endpoint.

### What’s this do?
Allows intercom details to be retrieved using `this.client.intercom.retreive()` which returns a promise, with resolve being called upon successful retrieval and reject being called upon retrieval failure.
