### PR TITLE
Add pluralized resources for Saved Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flippa",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "API client for Flippa.com.",
   "readme": "README.md",
   "main": "dist/Flippa.js",

--- a/src/Flippa.js
+++ b/src/Flippa.js
@@ -83,8 +83,16 @@ export default class Flippa {
     return new SavedSearch(this.client, savedSearchId);
   }
 
+  savedSearches() {
+    return new SavedSearch(this.client, null);
+  }
+
   savedSearchSubscription(savedSearchId) {
     return new SavedSearchSubscription(this.client, savedSearchId);
+  }
+
+  savedSearchSubscriptions() {
+    return new SavedSearchSubscription(this.client, null);
   }
 
   get supportEnquiries() {


### PR DESCRIPTION
Add missing pluralized resources:

- `SavedSearches`
- `SavedSearchSubscriptions`