### PR TITLE
Set the 'Content-Type' header to 'application/json' for each request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### head
 
+* Set `Content-Type` header to `application/json` for post and delete requests.
+
 ### 2.11.1
 
 * Allow usage of pluralized resource name for saved search and saved search

--- a/src/Client.js
+++ b/src/Client.js
@@ -24,6 +24,7 @@ export default class Client {
     var request = Request
       .post(this.baseEndpointURL + endpoint)
       .set("Accept", "application/json")
+      .set("Content-Type", "application/json")
       .send(params)
       .timeout(this.timeout);
 
@@ -38,6 +39,7 @@ export default class Client {
     var request = Request
       .del(this.baseEndpointURL + endpoint)
       .set("Accept", "application/json")
+      .set("Content-Type", "application/json")
       .send(params)
       .timeout(this.timeout);
 


### PR DESCRIPTION
### Background Context
The client does not set the `Content-Type` of the request to be `application/json` for `POST` and `DELETE` requests, which it should be doing to be a good internet citizen. This has the potential to break certain applications that require the correct `Content-Type` header to be set (for example, the https://github.com/node-nock/nock package.

### What's this do?
Sets the `Content-Type` header to `application/json` for `POST` and `DELETE` requests.

### Notes
It seems like browsers automatically add these headers if it detects JSON in the payload.