### PR TITLE
CORS compatibility fix for the /v3/sessions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### head
 
+### 2.11.4
+
+* Set `withCredentials` on request to support CORS cookie sessions
+
 ### 2.11.2
 
 * Set `Content-Type` header to `application/json` for post and delete requests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10
+FROM node:6.9.1-alpine
 
 ADD package.json /src/
 

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ build: Dockerfile
 	docker build --rm -t $(IMAGE) .
 
 shell:
-	docker run --rm -it -v $(PWD):/src $(IMAGE) bash
+	docker run --rm -it -v $(PWD):/src $(IMAGE) sh
 
 test:
 	docker run --rm -t $(IMAGE) npm run test
 
 publish: build
-	docker run --rm -it $(IMAGE) bash scripts/publish.sh
+	docker run --rm -it $(IMAGE) ./scripts/publish.sh
 
 tag:
 	git tag $(TAG)

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "webpack": "^1.9.8"
   },
   "dependencies": {
-    "bluebird": "^2.9.25",
+    "bluebird": "^3.4.7",
     "qs": "^4.0.0",
-    "superagent": "^1.2.0",
-    "superagent-bluebird-promise": "^2.0.2"
+    "superagent": "^3.4.4",
+    "superagent-bluebird-promise": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flippa",
-  "version": "2.11.2",
+  "version": "2.11.4",
   "description": "API client for Flippa.com.",
   "readme": "README.md",
   "main": "dist/Flippa.js",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ex
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -11,6 +11,7 @@ export default class Client {
   get(endpoint, params={}) {
     var request = Request
       .get(this.baseEndpointURL + endpoint)
+      .withCredentials()
       .query(qs.stringify(params))
       .set("Accept", "application/json")
       .timeout(this.timeout);
@@ -23,6 +24,7 @@ export default class Client {
   post(endpoint, params={}, cookies={}) {
     var request = Request
       .post(this.baseEndpointURL + endpoint)
+      .withCredentials()
       .set("Accept", "application/json")
       .set("Content-Type", "application/json")
       .send(params)
@@ -38,6 +40,7 @@ export default class Client {
   del(endpoint, params={}) {
     var request = Request
       .del(this.baseEndpointURL + endpoint)
+      .withCredentials()
       .set("Accept", "application/json")
       .set("Content-Type", "application/json")
       .send(params)


### PR DESCRIPTION
Enables https://github.com/flippa/marketplace-frontend/pull/969

## Background

CORS XHR requests need `withCredentials` set. See: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials . I also upgraded some stuff that ultimately proved unnecessary, but I'm including it anyway because all the tests pass.

## Testing

This has been tested against MFE master, both that it doesn't cause any errors, and that it achieves its intended objective of allowing cross dev/staging login.

## What's this PR do?

- Set `withCredentials` on _all_ post requests. I only want it on one endpoint, but I don't know a clean way to specify it
- Use Alpine, and bump Node to match Flippa MFE
- Version 2.11.3
 
