### PR TITLE
Remove bluebird dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "webpack": "^1.9.8"
   },
   "dependencies": {
-    "bluebird": "^3.4.7",
     "qs": "^4.0.0",
-    "superagent": "^3.4.4",
-    "superagent-bluebird-promise": "^4.1.0"
+    "superagent": "^3.4.4"
   }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,4 +1,4 @@
-import Request from "superagent-bluebird-promise";
+import Request from "superagent";
 import qs from "qs";
 
 export default class Client {
@@ -18,7 +18,7 @@ export default class Client {
 
     this._setAuthorizationHeader(request);
 
-    return request.promise();
+    return request;
   }
 
   post(endpoint, params={}, cookies={}) {
@@ -34,7 +34,7 @@ export default class Client {
 
     this._setAuthorizationHeader(request);
 
-    return request.promise();
+    return request;
   }
 
   del(endpoint, params={}) {
@@ -48,7 +48,7 @@ export default class Client {
 
     this._setAuthorizationHeader(request);
 
-    return request.promise();
+    return request;
   }
 
   _setAuthorizationHeader(request) {

--- a/src/Flippa.js
+++ b/src/Flippa.js
@@ -17,7 +17,6 @@ import Users from "./resources/Users";
 import PartnerPage from "./resources/PartnerPage";
 import Intercom from "./resources/Intercom";
 
-import Promise from "bluebird";
 
 export default class Flippa {
   constructor(opts={}) {


### PR DESCRIPTION
Bluebird is dependency of significant size, we're using very little of it's functionality. It doesn't make sense to use a fully-fledged promise library when we can replace it with native (or polyfilled) promises.

This PR removes `bluebird` and `superagent-bluebird-promise` in favour of native promises. 