### PR TITLE
Bump major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ### head
 
-### 2.12.0
+### 3.0.0
 
 * Preferred native promises over bluebird
 * Removed `bluebird`, `superagent-bluebird-promise`
+* Promises now require a polyfill
 
 ### 2.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### head
 
+### 2.12.0
+
+* Preferred native promises over bluebird
+* Removed `bluebird`, `superagent-bluebird-promise`
+
 ### 2.11.4
 
 * Set `withCredentials` on request to support CORS cookie sessions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flippa",
-  "version": "2.11.4",
+  "version": "3.0.0",
   "description": "API client for Flippa.com.",
   "readme": "README.md",
   "main": "dist/Flippa.js",


### PR DESCRIPTION
Bumping the version from my last PR - https://github.com/flippa/flippa-js/pull/38. Bumping minor version instead of patch for possible requirement of a polyfill. 

Also updated changelog to reflect changes from https://github.com/flippa/flippa-js/pull/38